### PR TITLE
Refactor RestAPI tests

### DIFF
--- a/WeatherCore/Package.swift
+++ b/WeatherCore/Package.swift
@@ -64,8 +64,7 @@ let package = Package(
         .testTarget(
             name: "NetworkingTests",
             dependencies: [
-                "Networking",
-                "NetworkingTestUtilities",
+                "Networking"
             ],
             path: "Sources/Foundation/NetworkingTests"
         ),
@@ -82,8 +81,7 @@ let package = Package(
             dependencies: [
                 "NetworkingTestUtilities",
                 "RestAPI",
-                "RestAPITestUtilities",
-                "LandingPage"
+                "RestAPITestUtilities"
             ],
             path: "Sources/WeatherFeature/RestAPITests"
         ),

--- a/WeatherCore/Sources/WeatherFeature/RestAPITests/RestAPITests.swift
+++ b/WeatherCore/Sources/WeatherFeature/RestAPITests/RestAPITests.swift
@@ -1,7 +1,6 @@
 import Foundation
 import NetworkingTestUtilities
 @testable import RestAPI
-@testable import LandingPage
 import RestAPITestUtilities
 import Testing
 
@@ -72,6 +71,23 @@ struct RestAPITests {
             // Then
             #expect(error is URLError)
             #expect(error as! URLError == URLError(.badServerResponse))
+        }
+    }
+    
+    struct WeatherModel:Decodable {
+        let location: Location
+        let current: Current
+        
+        struct Location: Decodable {
+            let name: String
+        }
+        
+        struct Current: Decodable {
+            let condition: Condition
+            
+            struct Condition: Decodable {
+                let text: String
+            }
         }
     }
 }


### PR DESCRIPTION
# What changed?
- [x] Remove import LandingPage from RestAPI Tests
- [x] Remove NetworkingUtilities from Networking Tests
- [x] Use own model to parse data from online in RestAPI Tests